### PR TITLE
Add type in validation rules.

### DIFF
--- a/lib/dsl.ex
+++ b/lib/dsl.ex
@@ -3,19 +3,31 @@ defmodule ProtoValidator.DSL do
     validator = ProtoValidator.Validator.get_validator()
 
     quote bind_quoted: [validator: validator] do
-      Enum.map(@validations, fn {field, rules} ->
-        rules = apply(validator, :translate_rules, [rules])
+      @doc """
+      Validate a field value
+      """
+      Enum.map(@validations, fn {field, [{:type, type} | rules]} ->
+        rules = validator.translate_rules(rules)
 
         def validate_value(unquote(field) = field, value) do
-          apply(
-            unquote(validator),
-            :validate_value,
-            [field, value, unquote(Macro.escape(rules))]
-          )
+          case ProtoValidator.Validator.validate_type(unquote(Macro.escape(type)), value) do
+            :ok ->
+              unquote(validator).validate_rule(field, value, unquote(Macro.escape(rules)))
+
+            error ->
+              error
+          end
         end
       end)
 
       def validate_value(field, _value), do: :ok
+
+      def validate(data) do
+        ProtoValidator.Utils.pipe_validates(@validations, fn {field, _rules} ->
+          value = Map.get(data, field)
+          validate_value(field, value)
+        end)
+      end
     end
   end
 

--- a/lib/proto_validator/protoc/cli.ex
+++ b/lib/proto_validator/protoc/cli.ex
@@ -19,13 +19,6 @@ defmodule ProtoValidator.Protoc.CLI do
       # debug
       # raise inspect(pkgs, limit: :infinity)
 
-      # msg = Google.Protobuf.FieldOptions.new()
-      # rules = %Validate.FieldRules{}
-      # msg = Google.Protobuf.FieldOptions.put_extension(msg, Validate.PbExtension, :rules, rules)
-      # raise inspect(Google.Protobuf.FieldOptions.get_extension(msg, Validate.PbExtension, :rules))
-
-      # debug end
-
       files =
         pkgs
         |> Enum.flat_map(fn pkg -> pkg.files end)

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -7,4 +7,26 @@ defmodule ProtoValidator.Utils do
     |> Stream.filter(&Kernel.match?({:error, _msg}, &1))
     |> Enum.at(0, :ok)
   end
+
+  defguard is_internal_type(type)
+           when type in [
+                  :integer,
+                  :double,
+                  :float,
+                  :int64,
+                  :uint64,
+                  :int32,
+                  :fixed64,
+                  :fixed32,
+                  :bool,
+                  :string,
+                  :group,
+                  :bytes,
+                  :uint32,
+                  :sfixed32,
+                  :sfixed64,
+                  :sint32,
+                  :sint64,
+                  :message
+                ]
 end

--- a/lib/validate.pb.ex
+++ b/lib/validate.pb.ex
@@ -8,11 +8,11 @@ defmodule Validate.FieldRules do
         }
   defstruct [:type, :message]
 
-  oneof :type, 0
+  oneof(:type, 0)
 
-  field :message, 17, optional: true, type: Validate.MessageRules
-  field :uint64, 6, optional: true, type: Validate.UInt64Rules, oneof: 0
-  field :repeated, 18, optional: true, type: Validate.RepeatedRules, oneof: 0
+  field(:message, 17, optional: true, type: Validate.MessageRules)
+  field(:uint64, 6, optional: true, type: Validate.UInt64Rules, oneof: 0)
+  field(:repeated, 18, optional: true, type: Validate.RepeatedRules, oneof: 0)
 end
 
 defmodule Validate.MessageRules do
@@ -24,7 +24,7 @@ defmodule Validate.MessageRules do
         }
   defstruct [:required]
 
-  field :required, 2, optional: true, type: :bool
+  field(:required, 2, optional: true, type: :bool)
 end
 
 defmodule Validate.UInt64Rules do
@@ -37,8 +37,8 @@ defmodule Validate.UInt64Rules do
         }
   defstruct [:lt, :gt]
 
-  field :lt, 2, optional: true, type: :uint64
-  field :gt, 4, optional: true, type: :uint64
+  field(:lt, 2, optional: true, type: :uint64)
+  field(:gt, 4, optional: true, type: :uint64)
 end
 
 defmodule Validate.RepeatedRules do
@@ -53,15 +53,15 @@ defmodule Validate.RepeatedRules do
         }
   defstruct [:min_items, :max_items, :unique, :items]
 
-  field :min_items, 1, optional: true, type: :uint64
-  field :max_items, 2, optional: true, type: :uint64
-  field :unique, 3, optional: true, type: :bool
-  field :items, 4, optional: true, type: Validate.FieldRules
+  field(:min_items, 1, optional: true, type: :uint64)
+  field(:max_items, 2, optional: true, type: :uint64)
+  field(:unique, 3, optional: true, type: :bool)
+  field(:items, 4, optional: true, type: Validate.FieldRules)
 end
 
 defmodule Validate.PbExtension do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
-  extend Google.Protobuf.FieldOptions, :rules, 1071, optional: true, type: Validate.FieldRules
+  extend(Google.Protobuf.FieldOptions, :rules, 1071, optional: true, type: Validate.FieldRules)
 end

--- a/lib/validator.ex
+++ b/lib/validator.ex
@@ -1,6 +1,8 @@
 defmodule ProtoValidator.Validator do
   @validator Application.get_env(:proto_validator, :validator, :vex)
 
+  import ProtoValidator.Utils, only: [pipe_validates: 2]
+
   def get_validator() do
     get_validator(@validator)
   end
@@ -12,4 +14,30 @@ defmodule ProtoValidator.Validator do
   def validate_uniq(value) do
     if Enum.uniq(value) == value, do: :ok, else: {:error, "values should be uniq"}
   end
+
+  @doc """
+  Validate the type of a field
+  """
+  @spec validate_type(atom() | {:repeated, atom()}, any()) :: :ok | {:error, String.t()}
+  def validate_type(_, nil), do: :ok
+
+  def validate_type({:repeated, type}, values) when is_list(values) do
+    pipe_validates(values, &validate_type(type, &1))
+  end
+
+  def validate_type({:repeated, type}, value) do
+    {:error, "#{inspect(value)} is not a list of #{inspect(type)}"}
+  end
+
+  def validate_type(type, value) do
+    ProtoValidator.validate(type, value)
+  end
+
+  def validate_internal_type(_, nil), do: :ok
+
+  def validate_internal_type(:uint64, value) when is_integer(value), do: :ok
+
+  def validate_internal_type(:uint64, value), do: {:error, "#{inspect(value)} is not integer"}
+
+  def validate_internal_type(_, _), do: :ok
 end

--- a/lib/validator/vex.ex
+++ b/lib/validator/vex.ex
@@ -1,9 +1,9 @@
 defmodule ProtoValidator.Validator.Vex do
   @moduledoc ""
 
-  def validate_value(field, value, rules) when is_list(rules) do
+  def validate_rule(field, value, rules) when is_list(rules) do
     rules
-    |> ProtoValidator.Utils.pipe_validates(fn rule -> validate_value(value, rule) end)
+    |> ProtoValidator.Utils.pipe_validates(fn rule -> validate_rule(value, rule) end)
     |> case do
       :ok -> :ok
       # TODO: Improve error message
@@ -11,40 +11,40 @@ defmodule ProtoValidator.Validator.Vex do
     end
   end
 
-  def validate_value(nil, {:items, _rule}), do: :ok
+  def validate_rule(nil, {:items, _rule}), do: :ok
 
-  def validate_value(nil, {:array, rule}) do
-    validate_value([], rule)
+  def validate_rule(nil, {:array, rule}) do
+    validate_rule([], rule)
   end
 
-  def validate_value(values, {:items, rule}) when is_list(values) do
-    ProtoValidator.Utils.pipe_validates(values, fn value -> validate_value(value, rule) end)
+  def validate_rule(values, {:items, rule}) when is_list(values) do
+    ProtoValidator.Utils.pipe_validates(values, fn value -> validate_rule(value, rule) end)
   end
 
-  def validate_value(values, {:array, rule}) when is_list(values) do
-    validate_value(values, rule)
+  def validate_rule(values, {:array, rule}) when is_list(values) do
+    validate_rule(values, rule)
   end
 
-  def validate_value(_values, {:array, _rule}) do
+  def validate_rule(_values, {:array, _rule}) do
     {:error, "should be a list"}
   end
 
-  def validate_value(value, {:function, {m, f}}) do
+  def validate_rule(value, {:function, {m, f}}) do
     apply(m, f, [value])
   end
 
-  def validate_value(value, {vex_module, options}) when is_list(options) do
+  def validate_rule(value, {vex_module, options}) when is_list(options) do
     apply(vex_module, :validate, [value, options])
   end
 
-  def validate_value(value, rule) do
+  def validate_rule(value, rule) do
     {:error, "Failed to validate value #{inspect(value)} against on rule: #{inspect(rule)}"}
   end
 
   @doc """
   Translate rules
   - raw rules:
-    [required: true, repeated: [items: [uint64: [gt: 0, lt: 90]], min_items: 0, unique: true]]
+    [type: :uint64, required: true, repeated: [items: [uint64: [gt: 0, lt: 90]], min_items: 0, unique: true]]
   - flatten:
     [
       required: true,
@@ -84,14 +84,6 @@ defmodule ProtoValidator.Validator.Vex do
   end
 
   def flatten_rules(rules), do: rules
-
-  [
-    required: true,
-    repeated: {:items, {:uint64, {:gt, 0}}},
-    repeated: {:items, {:uint64, {:lt, 90}}},
-    repeated: {:min_items, 0},
-    repeated: {:unique, true}
-  ]
 
   defp translate_rule({_, {:gt, v}}) do
     {Vex.Validators.Number, [greater_than: v, message: "should greater than #{v}"]}

--- a/test/proto_gen/example.pb.ex
+++ b/test/proto_gen/example.pb.ex
@@ -4,9 +4,9 @@ defmodule Examplepb.GENDER do
 
   @type t :: integer | :MALE | :FEMALE | :OTHER
 
-  field :MALE, 0
-  field :FEMALE, 1
-  field :OTHER, 2
+  field(:MALE, 0)
+  field(:FEMALE, 1)
+  field(:OTHER, 2)
 end
 
 defmodule Examplepb.User.Phone do
@@ -18,7 +18,7 @@ defmodule Examplepb.User.Phone do
         }
   defstruct [:phone_number]
 
-  field :phone_number, 1, type: :uint64
+  field(:phone_number, 1, type: :uint64)
 end
 
 defmodule Examplepb.User do
@@ -34,9 +34,9 @@ defmodule Examplepb.User do
         }
   defstruct [:id, :email, :gender, :phones, :following_ids]
 
-  field :id, 1, type: :uint64
-  field :email, 2, type: :string
-  field :gender, 3, type: Examplepb.GENDER, enum: true
-  field :phones, 4, repeated: true, type: Examplepb.User.Phone
-  field :following_ids, 5, repeated: true, type: :uint64
+  field(:id, 1, type: :uint64)
+  field(:email, 2, type: :string)
+  field(:gender, 3, type: Examplepb.GENDER, enum: true)
+  field(:phones, 4, repeated: true, type: Examplepb.User.Phone)
+  field(:following_ids, 5, repeated: true, type: :uint64)
 end

--- a/test/proto_gen/example.pb.validate.ex
+++ b/test/proto_gen/example.pb.validate.ex
@@ -2,11 +2,13 @@ defmodule ProtoValidator.Gen.Examplepb.User do
   @moduledoc false
   use ProtoValidator, entity: Examplepb.User
 
-  validate(:id, required: true, uint64: [gt: 0, lt: 90])
-  validate(:email, required: true)
-  validate(:phones, repeated: [min_items: 1])
+  validate(:id, type: :uint64, required: true, uint64: [gt: 0, lt: 90])
+  validate(:email, type: :string, required: true)
+  validate(:gender, type: Examplepb.Gender)
+  validate(:phones, type: {:repeated, Examplepb.User.Phone}, repeated: [min_items: 1])
 
   validate(:following_ids,
+    type: {:repeated, :uint64},
     repeated: [items: [uint64: [gt: 0, lt: 90]], min_items: 0, unique: true]
   )
 end
@@ -15,5 +17,5 @@ defmodule ProtoValidator.Gen.Examplepb.User.Phone do
   @moduledoc false
   use ProtoValidator, entity: Examplepb.User.Phone
 
-  validate(:phone_number, required: true, uint64: [gt: 1000, lt: 2000])
+  validate(:phone_number, type: :uint64, required: true, uint64: [gt: 1000, lt: 2000])
 end


### PR DESCRIPTION
This PR mainly are:
- Add `type` in validation rules to support more data type validation.
- Use type do validate field rather than `proto field_prop`.
- Make some changes based on the comments in https://github.com/tony612/protoc-gen-validate/pull/1.

Current generated code:
``` Elixir
defmodule ProtoValidator.Gen.Examplepb.User do
  @moduledoc false
  use ProtoValidator, entity: Examplepb.User

  validate(:id, required: true, uint64: [gt: 0, lt: 90])
  validate(:email, required: true)
  validate(:phones, repeated: [min_items: 1])

  validate(:following_ids,
    repeated: [items: [uint64: [gt: 0, lt: 90]], min_items: 0, unique: true]
  )
end
```
After change:
``` Elixir
defmodule ProtoValidator.Gen.Examplepb.User do
  @moduledoc false
  use ProtoValidator, entity: Examplepb.User

  validate(:id, type: :uint64, required: true, uint64: [gt: 0, lt: 90])
  validate(:email, type: :string, required: true)
  validate(:gender, type: Examplepb.Gender)
  validate(:phones, type: {:repeated, Examplepb.User.Phone}, repeated: [min_items: 1])

  validate(:following_ids,
    type: {:repeated, :uint64},
    repeated: [items: [uint64: [gt: 0, lt: 90]], min_items: 0, unique: true]
  )
end
```
And now we can validate list data:
``` Elixir
ProtoValidator.validate([user1, user2, user3])
```
Next step is to adding enum validation and more internal type validation(only `uint64` now).